### PR TITLE
fix: the epilog dir must also be created

### DIFF
--- a/slurm-prepilogue.spec
+++ b/slurm-prepilogue.spec
@@ -39,6 +39,7 @@ to verify the node is in good shape to run jobs
 %install
 rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT/usr/libexec/slurm/prolog/
+mkdir -p $RPM_BUILD_ROOT/usr/libexec/slurm/epilog/
 install checkpaths.sh $RPM_BUILD_ROOT/usr/libexec/slurm/prolog/
 install checkpaths_stat.sh $RPM_BUILD_ROOT/usr/libexec/slurm/prolog/
 install functions.sh $RPM_BUILD_ROOT/usr/libexec/slurm/prolog/


### PR DESCRIPTION
Has not been built anyway, so no version bump needed