### PR TITLE
set mailrc config file specifically in env

### DIFF
--- a/files/smail.sh
+++ b/files/smail.sh
@@ -23,6 +23,7 @@
 # Just pass through notifications without an ending status.
 
 MAIL=/bin/mail
+export MAILRC=/var/spool/slurm/.mailrc
 
 IFS=","
 array=($2)

--- a/slurm-prepilogue.spec
+++ b/slurm-prepilogue.spec
@@ -1,5 +1,5 @@
 # #
-# Copyright 2018-2018 Ghent University
+# Copyright 2018-2020 Ghent University
 #
 # This file is part of slurm-prepilogue
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -14,7 +14,7 @@
 
 Summary: Slurm prologue and epilogue scripts for HPCUGent
 Name: slurm-prepilogue
-Version: 0.9
+Version: 0.10
 Release: 1
 
 Group: Applications/System


### PR DESCRIPTION
so I was looking into why no mails were sent in slurm 20.11.06. after some tracing I found
```
open("./.mailrc", O_RDONLY) = -1 ENOENT (No such file or directory)
```

looking into where the script its `pwd` was I got `/` so that won't work. so setting it in the environment makes sure the config file for mail is picked up. 